### PR TITLE
Fix: Add missing jsdom dependency for Vitest.

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -30,6 +30,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-import": "^2.29.1",
     "firebase-functions-test": "^3.1.0",
+    "jsdom": "^24.0.0",
     "typescript": "^5.3.3"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^8.55.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.33",
     "prettier": "^3.2.4",
     "tailwindcss": "^3.4.1",


### PR DESCRIPTION
The CI/CD pipeline was failing due to a missing 'jsdom' dependency required by Vitest for running tests.

This commit addresses the issue by:
1.  Adding 'jsdom' to `devDependencies` in the root `package.json`.
2.  Adding 'jsdom' to `devDependencies` in `functions/package.json` for completeness, in case tests are run in that environment.

The Vitest configuration (`vitest.config.ts`) was reviewed and already correctly specifies `environment: 'jsdom'`, so no changes were needed there.

This should resolve the test execution errors in the CI/CD pipeline.